### PR TITLE
Reduce implementation complexity

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -303,7 +303,8 @@ workflows:
                 - bigquery
                 - clickhouse-cloud
                 - athena
-                - fabric
+                # todo: enable fabric when cicd catalog create/drop implemented in manage-test-db.sh
+                #- fabric
           filters:
             branches:
               only:

--- a/sqlmesh/core/config/connection.py
+++ b/sqlmesh/core/config/connection.py
@@ -1735,7 +1735,9 @@ class FabricConnectionConfig(MSSQLConnectionConfig):
     def _extra_engine_config(self) -> t.Dict[str, t.Any]:
         return {
             "database": self.database,
-            "catalog_support": CatalogSupport.FULL_SUPPORT,
+            # more operations than not require a specific catalog to be already active
+            # in particular, create/drop view, create/drop schema and querying information_schema
+            "catalog_support": CatalogSupport.REQUIRES_SET_CATALOG,
             "workspace_id": self.workspace_id,
             "tenant_id": self.tenant_id,
             "user": self.user,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,7 +478,7 @@ def make_mocked_engine_adapter(mocker: MockerFixture) -> t.Callable:
         connection_mock.cursor.return_value = cursor_mock
         cursor_mock.connection.return_value = connection_mock
         adapter = klass(
-            lambda: connection_mock,
+            lambda *args, **kwargs: connection_mock,
             dialect=dialect or klass.DIALECT,
             register_comments=register_comments,
             default_catalog=default_catalog,


### PR DESCRIPTION
I started reviewing https://github.com/TobikoData/sqlmesh/pull/4751 again but quickly realised there were some more fundamental problems. Namely, a lot of things were implemented that did not need to exist and I figured that there would be a lot of back-and-forth that would ultimately just end up getting fed into Claude and not actually addressing the underlying problems.

So this PR does the following:

- Strip out a bunch of the vibe code in favour of re-using existing constructs
- Change `CatalogSupport.FULL_SUPPORT` to `CatalogSupport.REQUIRES_SET_CATALOG` because it seems far more operations than not need the catalog to be set, including querying `INFORMATION_SCHEMA`
- Refactor the HTTP code into a separate class to keep it contained and remove some of the boilerplate
- Remove unnecessary checks like "ensure schema exists before creating view or table" - SQLMesh already does this
- Simplify connection factory override in `FabricEngineAdapter` constructor
- Fix unit tests

The result passes our integration test suite but I didn't run it against an actual project.

@fresioAS if you have something locally do you mind doublechecking it?